### PR TITLE
Minor fixes in Karma e Mocha

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -15,7 +15,7 @@ function makeDefaultConfig() {
     files: [KARMA_ENTRY],
     singleRun: !debug,
     autoWatch: debug,
-    frameworks: ['mocha', 'sinon-chai', 'webpack'],
+    frameworks: ['mocha', 'sinon-chai'],
     preprocessors: preprocessors,
     reporters: ['progress'],
     browsers: (debug ? ['PhantomJS', 'Chrome'] : ['PhantomJS']),

--- a/mocha.entry.js
+++ b/mocha.entry.js
@@ -30,8 +30,6 @@ var webpackConfigBase = {
 describe('[ModernizrWebpackPlugin] Build Tests', function () {
 
   beforeEach(function (done) {
-    this.timeout(5000);
-
     // reset config to base status
     webpackConfig = assign({}, webpackConfigBase);
     del(OUTPUT_PATH).then(function () {
@@ -40,8 +38,6 @@ describe('[ModernizrWebpackPlugin] Build Tests', function () {
   });
 
   it('should output a hashed filename', function (done) {
-    this.timeout(10000);
-
     var config = {filename: 'testing[hash]'};
     webpackConfig.plugins = [
       new HtmlWebpackPlugin(),
@@ -89,7 +85,7 @@ describe('[ModernizrWebpackPlugin] Build Tests', function () {
       fs.readFileAsync(path.resolve(OUTPUT_PATH, 'index.html'), 'utf8').then(function (data) {
         expect(/<script(.*)src="public\/entry-bundle.js">/.test(data)).to.be.true;
         done();
-      }).catch(function (error) { });
+      });
     }).catch(done);
   });
 


### PR DESCRIPTION
Changes made based on the comments left in the previous PR https://github.com/Gabri-G4M/modernizr-webpack-plugin/pull/1

Karma:
- Removed 'webpack' from list of _test_ frameworks

Mocha:
- Removed `timeout()` functions
- Removed unnecessary `catch()`